### PR TITLE
Use terse guard clause for git clone

### DIFF
--- a/infra/build/run.sh
+++ b/infra/build/run.sh
@@ -14,7 +14,7 @@ declare -r _TFSTATE_BUCKET_NAME='tfstate-metadiff.com'
 declare -r _RUN_TASK=$(jq -r .RUN_TASK <<< "$1")
 declare -r _GIT_BRANCH=$(jq -r .GIT_BRANCH <<< "$1")
 
-git clone --branch $_GIT_BRANCH $_GIT_REPO
+[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
 cd $_PROJECT_NAME
 
 build_package_application


### PR DESCRIPTION
## Summary
- Add terse guard clause before git clone to prevent errors if directory exists
- Makes the code consistent with other projects (e.g., regex-directed-graph-line-parser)

## Changes
```bash
# Before
git clone --branch $_GIT_BRANCH $_GIT_REPO

# After
[ -d "$_PROJECT_NAME" ] || git clone --branch $_GIT_BRANCH $_GIT_REPO
```

## Test plan
- Build process should work identically
- Guard clause prevents re-cloning if directory exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)