### PR TITLE
Remove build container after run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ EOM
 
 curl -v -sS -w '\n%{http_code}' \
   --data-binary "$JSON_BODY" \
-  "https://api.conjob.io/job/run?image=$IMAGE_NAME" \
+  "https://api.conjob.io/job/run?image=$IMAGE_NAME&remove=true" \
   | tee /tmp/foo \
   | sed '$d' && \
   [ "$(tail -1 /tmp/foo)" -eq 200 ]

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   defaultCommandTimeout: 30000,
   env: {
     backendUrl:
-      'https://api.conjob.io/job/run?image=scottg489/metadiff:latest'
+      'https://api.conjob.io/job/run?image=scottg489/metadiff:latest&remove=true'
   },
   e2e: {
     setupNodeEvents (on, config) {},

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,7 @@ const App = () => {
   async function fetchDiffInfo (postData: string) {
     try {
       const response = await fetch(
-        'https://api.conjob.io/job/run?image=scottg489/metadiff:latest',
+        'https://api.conjob.io/job/run?image=scottg489/metadiff:latest&remove=true',
         {
           method: 'POST',
           body: postData


### PR DESCRIPTION
Keeping these containers around indefinitely uses up too much disk space. We already have the logs in github and we rarely if ever need the container around for any purpose like debugging.

Adds `&remove=true` to conjob API calls in build.sh, src/App.tsx, and cypress.config.ts.