### PR TITLE
Use shared renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,124 +1,40 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ],
+  "extends": ["github>ScottG489/renovate-config"],
   "automergeType": "branch",
   "packageRules": [
     {
       "groupName": "node version",
-      "matchDatasources": [
-        "node-version",
-        "node-version"
-      ],
-      "matchPackageNames": [
-        "node",
-        "nodejs"
-      ]
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "matchDatasources": ["node-version", "node-version"],
+      "matchPackageNames": ["node", "nodejs"]
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile$/"
-      ],
-      "matchStrings": [
-        "ARG NODE_VERSION=(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": ["ARG NODE_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "node",
       "datasourceTemplate": "node-version"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-security&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-updates&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "\\s+(?<depName>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[^\\s\\\\]+)"
-      ],
-      "datasourceTemplate": "deb",
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?suite=noble-backports&components=main,universe,restricted,multiverse&binaryArch=amd64"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "ARG TERRAFORM_VERSION=(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
+      "matchStrings": ["ARG TERRAFORM_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "hashicorp/terraform",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "ARG AWSCLI_VERSION=(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/(^|/)Dockerfile($|\\.)/"],
+      "matchStrings": ["ARG AWSCLI_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "aws/aws-cli",
       "datasourceTemplate": "github-tags"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile($|\\.)/"
-      ],
-      "matchStrings": [
-        "ARG HADOLINT_VERSION=(?<currentValue>\\S+)"
-      ],
-      "depNameTemplate": "hadolint/hadolint",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Dockerfile$/"
-      ],
-      "matchStrings": [
-        "ARG NVM_VERSION=(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": ["ARG NVM_VERSION=(?<currentValue>\\S+)"],
       "depNameTemplate": "nvm-sh/nvm",
       "datasourceTemplate": "github-releases"
     }


### PR DESCRIPTION
## Summary
- Replace inline renovate configuration with shared preset from `ScottG489/renovate-config`
- Remove duplicated rules (extends, packageRules, customManagers) that are now inherited from the shared config
- Keep only repo-specific configuration that isn't in the shared preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)